### PR TITLE
Make rewriter no longer a singleton

### DIFF
--- a/src/createHtmlCloneWithScriptTags.ts
+++ b/src/createHtmlCloneWithScriptTags.ts
@@ -1,11 +1,11 @@
-const rewriter = new HTMLRewriter()
-
 export default async function createHtmlCloneWithScriptTags (
   htmlFilePath: string,
   entrypoints: string[],
   fileName: string,
   title?: string
 ): Promise<File> {
+  const rewriter = new HTMLRewriter()
+
   const headElementHandler = {
     element (el: HTMLRewriterTypes.Element) {
       if (el.tagName !== 'head') return


### PR DESCRIPTION
When I was using watch to rebuild my bundle I found that I would get multiple copies of the script tag in my head tag. Found out it's because the rewriter is shared and every time you use the plugin it adds to the on head. This should fix this issue.