### PR TITLE
Add publicPath option

### DIFF
--- a/out/HtmlBunPlugin.d.ts
+++ b/out/HtmlBunPlugin.d.ts
@@ -1,9 +1,10 @@
-import type { BunPlugin } from 'bun';
+import type { BunPlugin } from "bun";
+
 export interface HtmlBunPluginConfig {
-    // something
-    filename: string
-    title?: string;
-    template?: string;
+  filename: string;
+  title?: string;
+  template?: string;
+  publicPath?: string;
 }
 /**
  *
@@ -11,6 +12,8 @@ export interface HtmlBunPluginConfig {
  * - filename: Defaults to 'index.html'. Required if passing in an options object.
  * - title?: adds a title tag with the provided string. Defaults to 'Bun App'
  * - template?: path to a template HTML file to inject entries and title into
+ * - publicPath?: the base path that the entrypoint will be fetched from, defaults to './'
  */
 declare function HtmlBunPlugin(config?: HtmlBunPluginConfig): BunPlugin;
+
 export default HtmlBunPlugin;

--- a/src/HtmlBunPlugin.ts
+++ b/src/HtmlBunPlugin.ts
@@ -9,6 +9,7 @@ export interface HtmlBunPluginConfig {
   filename: string
   title?: string
   template?: string
+  publicPath?: string
 }
 
 /**
@@ -17,8 +18,9 @@ export interface HtmlBunPluginConfig {
  * - filename: Defaults to 'index.html'. Required if passing in an options object.
  * - title?: adds a title tag with the provided string. Defaults to 'Bun App'
  * - template?: path to a template HTML file to inject entries and title into
+ * - publicPath?: the base path that the entrypoint will be fetched from, defaults to './'
  */
-function HtmlBunPlugin (config: HtmlBunPluginConfig = { filename: 'index.html', title: 'Bun App' }): BunPlugin {
+function HtmlBunPlugin (config: HtmlBunPluginConfig = { filename: 'index.html', title: 'Bun App', publicPath: './' }): BunPlugin {
   return {
     name: 'HtmlBunPlugin',
     async setup (build: PluginBuilder) {
@@ -29,7 +31,8 @@ function HtmlBunPlugin (config: HtmlBunPluginConfig = { filename: 'index.html', 
         config.template ?? defautHtmlPath,
         build.config.entrypoints,
         config.filename,
-        config.title
+        config.title,
+        config.publicPath
       )
 
       try {

--- a/src/createHtmlCloneWithScriptTags.ts
+++ b/src/createHtmlCloneWithScriptTags.ts
@@ -2,7 +2,8 @@ export default async function createHtmlCloneWithScriptTags (
   htmlFilePath: string,
   entrypoints: string[],
   fileName: string,
-  title?: string
+  title?: string,
+  publicPath: string = './'
 ): Promise<File> {
   const rewriter = new HTMLRewriter()
 
@@ -10,7 +11,7 @@ export default async function createHtmlCloneWithScriptTags (
     element (el: HTMLRewriterTypes.Element) {
       if (el.tagName !== 'head') return
 
-      addScriptTags(el, entrypoints)
+      addScriptTags(el, entrypoints, publicPath);
       // add title element
       if (title !== undefined) addTitleTag(el, title)
     }
@@ -23,11 +24,11 @@ export default async function createHtmlCloneWithScriptTags (
   return new File([newHtmlBlob], fileName, { type: newHtmlBlob.type })
 }
 
-function addScriptTags (el: HTMLRewriterTypes.Element, entrypoints: string[], insertComments: boolean = true): void {
+function addScriptTags (el: HTMLRewriterTypes.Element, entrypoints: string[], publicPath: string, insertComments: boolean = true): void {
   // add sript tags for entry points
   const fileNames = parseScriptNamesFromEntryPoints(entrypoints) // replaceExtensionsWithJs(filePathsToFileNames(entrypoints))
   const scriptTags = fileNames.map(fileName =>
-    `  <script src='./${fileName}' defer></script>\n`
+    `  <script src='${publicPath}${fileName}' defer></script>\n`
   )
 
   if (insertComments) el.append('  <!-- The following <script> tags added via HTMLBunPlugin -->\n', { html: true })


### PR DESCRIPTION
I experimented with this plugin for a side project of mine and found that the public path being set to `./` is kind of presumptuous. This PR makes the publicPath configurable. This comes in handy when using a specific prefix for serving static files, or when using client side routing with for example React-Router.

Backwards compatibility is kept by defaulting the value to `./`.

I believe this to be in line with [HtmlWebpackPlugin](https://github.com/jantimon/html-webpack-plugin#options:~:text=inject%3Afalse%20example-,publicPath,-%7BString%7C%27auto%27%7D)